### PR TITLE
fix:background-imageのアセット指定先画像ファイル名修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body style="background-image: url(<%= asset_path('background.jpg') %>)" class="bg-cover bg-center min-h-screen">
+  <body style="background-image: url(<%= asset_path('background.jpeg') %>)" class="bg-cover bg-center min-h-screen">
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
# 概要
デプロイ後にアプリケーションにアクセスするとエラー画面が出現しました。背景画像の指定先ファイル名が間違っていたため、修正しました。
# エラーメッセージ
![2d33506a9f04fa4762f96e7cea09eaec](https://github.com/user-attachments/assets/ddecb2a0-29c8-4dda-89dd-823bb658c036)