### PR TITLE
fix:タイマー時間修正、タイマー開始、終了時音声ミュート

### DIFF
--- a/app/javascript/timer.js
+++ b/app/javascript/timer.js
@@ -12,7 +12,7 @@ document.addEventListener("turbo:load", function () {
   // ポモタイマーストップ、再開するためのインターバルid
   let nIntervId;
   // ポモ残り時間。初期値は25分
-  let remainingTime = 600000;
+  let remainingTime = 1500000;
   // ポモ変数
   let i = 0;
   // ポモドーロ回数
@@ -73,7 +73,7 @@ document.addEventListener("turbo:load", function () {
 
   // 学習再開時の処理記入
   const resumeStudying = () => {
-    remainingTime = 600000;
+    remainingTime = 1500000;
     learningStatus = true;
     intervalComment.innerHTML = "";
     startStopButton.value = "スタート";

--- a/app/views/timers/index.html.erb
+++ b/app/views/timers/index.html.erb
@@ -20,8 +20,9 @@
 
   </div>
 </div>
-  <%= audio_tag("howling_of_wolves.mp3", class: "cry")%>
-  <%= audio_tag("dog_cry.mp3", class: "cry")%>
-  <%= audio_tag("cat_cry.mp3", class: "cry")%>
-  <%= audio_tag("horse_cry.mp3", class: "cry")%>
+
+  <%= audio_tag("howling_of_wolves.mp3", muted: true , class: "cry")%>
+  <%= audio_tag("dog_cry.mp3", muted: true , class: "cry")%>
+  <%= audio_tag("cat_cry.mp3", muted: true , class: "cry")%>
+  <%= audio_tag("horse_cry.mp3", muted: true , class: "cry")%>
 


### PR DESCRIPTION
# 概要
- ポモドーロタイマーが10分にしてしまったので、25分に修正
- ミュート機能を実装してないため、audioにmuted属性を付与